### PR TITLE
front: css: use a real default font

### DIFF
--- a/baobab.front/less/event.less
+++ b/baobab.front/less/event.less
@@ -46,7 +46,6 @@ body {
 
     > span {
       margin-top: 10px;
-      font-family: Roboto;
       font-size: 14px;
       font-style: italic;
       display: block;
@@ -137,8 +136,6 @@ body > article > div {
   overflow-y: auto;
 
   height: 80%;
-
-  font-family: "Roboto";
   font-size: 16px;
   h1, h2, h3, h4, h5, h6 {
     margin-top: 5px;

--- a/baobab.front/less/timeline.less
+++ b/baobab.front/less/timeline.less
@@ -1,10 +1,9 @@
 @body-background: #fafafa;
 
-html {
-}
 body {
   overflow: hidden;
   background-color: @body-background;
+  font-family: 'Roboto', sans-serif;
 }
 #container {
   height: 100%;


### PR DESCRIPTION
Maybe you like serif for description, but since you load Roboto, it's quite heretic, isn't it? :smiley:

| Before | After |
| --- | --- |
| ![image](https://cloud.githubusercontent.com/assets/846943/10771472/3db215dc-7cf1-11e5-90d1-1f8e8fc4db06.png) | ![image](https://cloud.githubusercontent.com/assets/846943/10771497/62da1b66-7cf1-11e5-9565-2433f2badc03.png) |

